### PR TITLE
Improved pom.xml metdata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,23 @@
   <version>1.3.1-SNAPSHOT</version>
   <name>cloudi_api_java</name>
   <url>http://www.cloudi.org</url>
+  <licenses>
+    <license>
+      <name>BSD-style</name>
+      <url>http://www.opensource.org/licenses/bsd-license.php</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <name>Michael Truog</name>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git@github.com:CloudI/cloudi_api_java.git</connection>
+    <developerConnection>scm:git:git@github.com:CloudI/cloudi_api_java.git</developerConnection>
+    <url>git@github.com:CloudI/cloudi_api_java.git</url>
+  </scm>
   <dependencies>
 	<dependency>
 		<groupId>org.erlang.otp</groupId>


### PR DESCRIPTION
Improved `pom.xml` to get it up to Sonatype Maven Repo standards.

http://central.sonatype.org/pages/requirements.html#sufficient-metadata
